### PR TITLE
perf: accelerate canonical JSON and workflow clients

### DIFF
--- a/.changeset/fast-canonical-json.md
+++ b/.changeset/fast-canonical-json.md
@@ -2,4 +2,4 @@
 "effect-encore": patch
 ---
 
-Remove quadratic work from canonical JSON encoding.
+Remove quadratic work from canonical JSON encoding. Reuse the immutable workflow client reference that each layer owns.

--- a/.changeset/fast-canonical-json.md
+++ b/.changeset/fast-canonical-json.md
@@ -1,0 +1,5 @@
+---
+"effect-encore": patch
+---
+
+Remove quadratic work from canonical JSON encoding.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gate:test": "\"$npm_execpath\" test --tsconfig-override=tsconfig.json",
     "gate:build": "\"$npm_execpath\" --bun tsdown",
     "build": "\"$npm_execpath\" --bun tsdown",
+    "bench:canonical-json": "bun scripts/benchmark-canonical-json.ts",
     "release": "\"$npm_execpath\" run build && changeset publish",
     "version": "changeset version",
     "prepare": "lefthook install && effect-tsgo patch"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "gate:test": "\"$npm_execpath\" test --tsconfig-override=tsconfig.json",
     "gate:build": "\"$npm_execpath\" --bun tsdown",
     "build": "\"$npm_execpath\" --bun tsdown",
+    "bench:actor": "bun scripts/benchmark-actor-messaging.ts",
     "bench:canonical-json": "bun scripts/benchmark-canonical-json.ts",
+    "bench:workflow": "bun scripts/benchmark-workflow-messaging.ts",
     "release": "\"$npm_execpath\" run build && changeset publish",
     "version": "changeset version",
     "prepare": "lefthook install && effect-tsgo patch"

--- a/scripts/benchmark-actor-messaging.ts
+++ b/scripts/benchmark-actor-messaging.ts
@@ -1,0 +1,115 @@
+import { Effect, Layer, ManagedRuntime, Schema } from "effect";
+import { ShardingConfig } from "effect/unstable/cluster";
+import { Actor } from "../src/index.js";
+
+const Messaging = Actor.fromEntity("MessagingBenchmark", {
+  Execute: {
+    payload: { id: Schema.String, value: Schema.Number },
+    success: Schema.Number,
+    id: (payload: { readonly id: string }) => payload.id,
+  },
+  Send: {
+    payload: { id: Schema.String, value: Schema.Number },
+    success: Schema.Number,
+    persisted: true,
+    id: (payload: { readonly id: string }) => payload.id,
+  },
+});
+
+const ShardingConfigTest = ShardingConfig.layer({
+  shardsPerGroup: 300,
+  entityMailboxCapacity: 10_000,
+  entityTerminationTimeout: 0,
+});
+
+const MessagingTest = Layer.provide(
+  Actor.toTestLayer(Messaging, {
+    Execute: ({ operation }) => Effect.succeed(operation.value + 1),
+    Send: ({ operation }) => Effect.succeed(operation.value + 1),
+  }),
+  ShardingConfigTest,
+);
+
+const runtime = ManagedRuntime.make(MessagingTest);
+
+const median = (samples: Array<number>): number => {
+  samples.sort((left, right) => left - right);
+  return samples[2];
+};
+
+const measureSync = (iterations: number, operation: (index: number) => unknown): number => {
+  for (let index = 0; index < iterations; index++) operation(index);
+  const samples: Array<number> = [];
+  for (let sample = 0; sample < 5; sample++) {
+    const startedAt = Bun.nanoseconds();
+    for (let index = 0; index < iterations; index++) operation(index);
+    samples.push((Bun.nanoseconds() - startedAt) / iterations);
+  }
+  return median(samples);
+};
+
+const measureEffect = <A, E>(
+  iterations: number,
+  operation: (index: number) => Effect.Effect<A, E, Messaging["Context"]>,
+): Promise<number> =>
+  runtime.runPromise(
+    Effect.gen(function* () {
+      for (let index = 0; index < iterations; index++) yield* operation(index);
+      const samples: Array<number> = [];
+      for (let sample = 0; sample < 5; sample++) {
+        const startedAt = Bun.nanoseconds();
+        for (let index = 0; index < iterations; index++) yield* operation(index);
+        samples.push((Bun.nanoseconds() - startedAt) / iterations);
+      }
+      return median(samples);
+    }),
+  );
+
+const payload = { id: "same-entity", value: 1 };
+const actorRef = await runtime.runPromise(
+  Effect.gen(function* () {
+    const factory = yield* Messaging.Context;
+    return yield* factory(payload.id);
+  }),
+);
+const operationValue = Messaging.Execute.make(payload);
+const rows: Array<readonly [string, number]> = [
+  ["make", measureSync(1_000_000, () => Messaging.Execute.make(payload))],
+  ["executionId effect", measureSync(1_000_000, () => Messaging.Execute.executionId(payload))],
+  [
+    "executionId runSync",
+    measureSync(100_000, () => Effect.runSync(Messaging.Execute.executionId(payload))),
+  ],
+  ["execute, same entity", await measureEffect(10_000, () => Messaging.Execute.execute(payload))],
+  [
+    "actor ref factory, same entity",
+    await measureEffect(10_000, () =>
+      Effect.gen(function* () {
+        const factory = yield* Messaging.Context;
+        return yield* factory(payload.id);
+      }),
+    ),
+  ],
+  [
+    "actor ref execute, prebuilt operation",
+    await measureEffect(10_000, () => actorRef.execute(operationValue)),
+  ],
+  [
+    "actor ref execute, new operation",
+    await measureEffect(10_000, () => actorRef.execute(Messaging.Execute.make(payload))),
+  ],
+  [
+    "execute, 100 entities",
+    await measureEffect(10_000, (index) =>
+      Messaging.Execute.execute({ id: `entity-${index % 100}`, value: index }),
+    ),
+  ],
+  ["send, same entity", await measureEffect(10_000, () => Messaging.Send.send(payload))],
+];
+
+console.log("actor operation\tns/op\tops/s");
+for (const [name, nanoseconds] of rows) {
+  console.log(`${name}\t${nanoseconds.toFixed(0)}\t${(1_000_000_000 / nanoseconds).toFixed(0)}`);
+}
+
+await runtime.dispose();

--- a/scripts/benchmark-canonical-json.ts
+++ b/scripts/benchmark-canonical-json.ts
@@ -1,0 +1,131 @@
+import { BunCrypto } from "@effect/platform-bun";
+import { Crypto, Effect, Encoding, ManagedRuntime, Order, Schema } from "effect";
+import { canonicalJsonSha256, canonicalJsonString } from "../src/canonical-json.js";
+
+const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Json));
+const textEncoder = new TextEncoder();
+
+const legacyCanonicalJsonString = (value: Schema.Json): string => {
+  if (Array.isArray(value)) return `[${value.map(legacyCanonicalJsonString).join(",")}]`;
+  if (!Schema.is(Schema.JsonObject)(value)) return encodeJson(value);
+  return `{${Object.entries(value)
+    .sort(([left], [right]) => Order.String(left, right))
+    .map(([key, entry]) => `${encodeJson(key)}:${legacyCanonicalJsonString(entry)}`)
+    .join(",")}}`;
+};
+
+const deepJson = (depth: number): Schema.Json => {
+  let value: Schema.Json = 0;
+  for (let index = 0; index < depth; index++) value = { value };
+  return value;
+};
+
+const legacyCanonicalJsonSha256 = Effect.fn("benchmark/legacyCanonicalJsonSha256")(function* (
+  value: Schema.Json,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const digest = yield* crypto.digest(
+    "SHA-256",
+    textEncoder.encode(legacyCanonicalJsonString(value)),
+  );
+  return Encoding.encodeHex(digest);
+});
+
+const fixtures: ReadonlyArray<{
+  readonly name: string;
+  readonly iterations: number;
+  readonly value: Schema.Json;
+}> = [
+  {
+    name: "flat object, 100 keys",
+    iterations: 1_000,
+    value: Object.fromEntries(
+      Array.from({ length: 100 }, (_, index) => [`key-${99 - index}`, index]),
+    ),
+  },
+  {
+    name: "nested object, 100 keys",
+    iterations: 500,
+    value: Object.fromEntries(
+      Array.from({ length: 100 }, (_, index) => [
+        `key-${99 - index}`,
+        { a: [index, index + 1, index + 2], z: index },
+      ]),
+    ),
+  },
+  {
+    name: "integer-key object, 100 keys",
+    iterations: 1_000,
+    value: Object.fromEntries(Array.from({ length: 100 }, (_, index) => [String(index), index])),
+  },
+  {
+    name: "array, 1,000 items",
+    iterations: 500,
+    value: Array.from({ length: 1_000 }, (_, index) => index),
+  },
+  {
+    name: "object, depth 5,000",
+    iterations: 3,
+    value: deepJson(5_000),
+  },
+];
+
+const measure = (iterations: number, operation: () => string): number => {
+  operation();
+  const samples: Array<number> = [];
+  for (let sample = 0; sample < 5; sample++) {
+    const startedAt = Bun.nanoseconds();
+    for (let index = 0; index < iterations; index++) operation();
+    samples.push((Bun.nanoseconds() - startedAt) / iterations);
+  }
+  samples.sort((left, right) => left - right);
+  return samples[2];
+};
+
+const measureEffect = (
+  iterations: number,
+  operation: Effect.Effect<string, unknown, Crypto.Crypto>,
+): Effect.Effect<number, unknown, Crypto.Crypto> =>
+  Effect.gen(function* () {
+    yield* operation;
+    const samples: Array<number> = [];
+    for (let sample = 0; sample < 5; sample++) {
+      const startedAt = Bun.nanoseconds();
+      for (let index = 0; index < iterations; index++) {
+        yield* operation;
+      }
+      samples.push((Bun.nanoseconds() - startedAt) / iterations);
+    }
+    samples.sort((left, right) => left - right);
+    return samples[2];
+  });
+
+console.log("fixture\tlegacy ns/op\tcurrent ns/op\tspeedup");
+for (const fixture of fixtures) {
+  const expected = legacyCanonicalJsonString(fixture.value);
+  const actual = canonicalJsonString(fixture.value);
+  if (actual !== expected) {
+    throw new Error(`canonical JSON mismatch for ${fixture.name}`);
+  }
+
+  const legacy = measure(fixture.iterations, () => legacyCanonicalJsonString(fixture.value));
+  const current = measure(fixture.iterations, () => canonicalJsonString(fixture.value));
+  console.log(
+    `${fixture.name}\t${legacy.toFixed(0)}\t${current.toFixed(0)}\t${(legacy / current).toFixed(1)}x`,
+  );
+}
+
+const runtime = ManagedRuntime.make(BunCrypto.layer);
+const hashFixture = fixtures[1];
+if (hashFixture === undefined) throw new Error("hash benchmark fixture is missing");
+const legacyHash = await runtime.runPromise(
+  measureEffect(100, legacyCanonicalJsonSha256(hashFixture.value)),
+);
+const currentHash = await runtime.runPromise(
+  measureEffect(100, canonicalJsonSha256(hashFixture.value)),
+);
+console.log("\nEffect SHA-256 fixture\tlegacy ns/op\tcurrent ns/op\tspeedup");
+console.log(
+  `${hashFixture.name}\t${legacyHash.toFixed(0)}\t${currentHash.toFixed(0)}\t${(legacyHash / currentHash).toFixed(1)}x`,
+);
+await runtime.dispose();

--- a/scripts/benchmark-workflow-messaging.ts
+++ b/scripts/benchmark-workflow-messaging.ts
@@ -1,0 +1,100 @@
+import { Effect, ManagedRuntime, Schema } from "effect";
+import { Actor } from "../src/index.js";
+
+const WorkflowMessaging = Actor.fromWorkflow("WorkflowMessagingBenchmark", {
+  payload: { id: Schema.String, value: Schema.Number },
+  success: Schema.Number,
+  id: (payload: { readonly id: string }) => payload.id,
+});
+
+const WorkflowMessagingTest = Actor.toTestLayer(WorkflowMessaging, (payload) =>
+  Effect.succeed(payload.value + 1),
+);
+
+const runtime = ManagedRuntime.make(WorkflowMessagingTest);
+
+const median = (samples: Array<number>): number => {
+  samples.sort((left, right) => left - right);
+  return samples[2];
+};
+
+const measureSync = (iterations: number, operation: (index: number) => unknown): number => {
+  for (let index = 0; index < iterations; index++) operation(index);
+  const samples: Array<number> = [];
+  for (let sample = 0; sample < 5; sample++) {
+    const startedAt = Bun.nanoseconds();
+    for (let index = 0; index < iterations; index++) operation(index);
+    samples.push((Bun.nanoseconds() - startedAt) / iterations);
+  }
+  return median(samples);
+};
+
+const measureEffect = <A, E, R>(
+  iterations: number,
+  operation: (index: number) => Effect.Effect<A, E, R>,
+): Promise<number> =>
+  runtime.runPromise(
+    Effect.gen(function* () {
+      for (let index = 0; index < iterations; index++) yield* operation(index);
+      const samples: Array<number> = [];
+      for (let sample = 0; sample < 5; sample++) {
+        const startedAt = Bun.nanoseconds();
+        for (let index = 0; index < iterations; index++) yield* operation(index);
+        samples.push((Bun.nanoseconds() - startedAt) / iterations);
+      }
+      return median(samples);
+    }),
+  );
+
+const payload = { id: "same-workflow", value: 1 };
+const executionId = await runtime.runPromise(WorkflowMessaging.executionId(payload));
+const actorRef = await runtime.runPromise(
+  Effect.gen(function* () {
+    const factory = yield* WorkflowMessaging.Context;
+    return yield* factory(executionId);
+  }),
+);
+const operationValue = WorkflowMessaging.make(payload);
+let executeId = 0;
+let sendId = 0;
+const rows: Array<readonly [string, number]> = [
+  ["make", measureSync(1_000_000, () => WorkflowMessaging.make(payload))],
+  ["executionId effect", measureSync(100_000, () => WorkflowMessaging.executionId(payload))],
+  ["executionId run", await measureEffect(10_000, () => WorkflowMessaging.executionId(payload))],
+  ["execute, same id", await measureEffect(1_000, () => WorkflowMessaging.execute(payload))],
+  [
+    "actor ref factory, same id",
+    await measureEffect(10_000, () =>
+      Effect.gen(function* () {
+        const factory = yield* WorkflowMessaging.Context;
+        return yield* factory(executionId);
+      }),
+    ),
+  ],
+  [
+    "actor ref execute, prebuilt operation",
+    await measureEffect(1_000, () => actorRef.execute(operationValue)),
+  ],
+  [
+    "execute, unique ids",
+    await measureEffect(1_000, () => {
+      executeId++;
+      return WorkflowMessaging.execute({ id: `execute-${executeId}`, value: executeId });
+    }),
+  ],
+  ["send, same id", await measureEffect(1_000, () => WorkflowMessaging.send(payload))],
+  [
+    "send, unique ids",
+    await measureEffect(1_000, () => {
+      sendId++;
+      return WorkflowMessaging.send({ id: `send-${sendId}`, value: sendId });
+    }),
+  ],
+];
+
+console.log("workflow operation\tns/op\tops/s");
+for (const [name, nanoseconds] of rows) {
+  console.log(`${name}\t${nanoseconds.toFixed(0)}\t${(1_000_000_000 / nanoseconds).toFixed(0)}`);
+}
+
+await runtime.dispose();

--- a/src/canonical-json.ts
+++ b/src/canonical-json.ts
@@ -1,18 +1,132 @@
-import { Crypto, Effect, Encoding, Order, Schema } from "effect";
+import { Crypto, Effect, Encoding, Predicate, Schema } from "effect";
 
 const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Json));
-const isJsonObject = Schema.is(Schema.JsonObject);
+const decodeJson = Schema.decodeUnknownSync(Schema.Json);
 const textEncoder = new TextEncoder();
 const isJsonArray = (value: Schema.Json): value is Schema.JsonArray => Array.isArray(value);
+const isJsonObject = (value: Schema.Json): value is Schema.JsonObject =>
+  Predicate.isObject(value) && !Array.isArray(value);
+
+type JsonPrimitive = Exclude<Schema.Json, Schema.JsonArray | Schema.JsonObject>;
+
+const encodeJsonPrimitive = (value: JsonPrimitive): string => {
+  if (Predicate.isNull(value)) return "null";
+  if (Predicate.isBoolean(value)) {
+    if (value) return "true";
+    return "false";
+  }
+  if (Predicate.isNumber(value)) {
+    if (!Number.isFinite(value)) return encodeJson(value);
+    return String(value);
+  }
+  // oxlint-disable-next-line effect/noGlobals -- JSON string escaping is the canonical wire format. Schema validation already established the string member.
+  const encoded = JSON.stringify(value);
+  if (!Predicate.isString(encoded)) return encodeJson(value);
+  return encoded;
+};
+
+const jsonObjectEntry = (value: Schema.JsonObject, key: string): Schema.Json => {
+  const entry = value[key];
+  if (Predicate.isUndefined(entry)) return decodeJson(entry);
+  return entry;
+};
+
+const canonicalJsonStringExact = (value: Schema.Json): string => {
+  if (isJsonArray(value)) {
+    let output = "[";
+    let first = true;
+    for (const entry of value) {
+      if (first) first = false;
+      else output += ",";
+      output += canonicalJsonStringExact(entry);
+    }
+    return `${output}]`;
+  }
+  if (!isJsonObject(value)) return encodeJsonPrimitive(value);
+
+  let output = "{";
+  const keys = Object.keys(value).sort();
+  let first = true;
+  for (const key of keys) {
+    if (first) first = false;
+    else output += ",";
+    output += `${encodeJsonPrimitive(key)}:${canonicalJsonStringExact(jsonObjectEntry(value, key))}`;
+  }
+  return `${output}}`;
+};
+
+const isArrayIndexKey = (key: string): boolean => {
+  const index = Number(key);
+  return Number.isInteger(index) && index >= 0 && index < 4_294_967_295 && String(index) === key;
+};
+
+const hasNativeKeyOrderConflict = (value: Schema.JsonObject): boolean => {
+  const keys = Object.keys(value).sort();
+  let previousIndex = -1;
+  let foundNonIndex = false;
+  for (const key of keys) {
+    if (!isArrayIndexKey(key)) {
+      foundNonIndex = true;
+      continue;
+    }
+    if (foundNonIndex) return true;
+    const index = Number(key);
+    if (index < previousIndex) return true;
+    previousIndex = index;
+  }
+  return false;
+};
+
+interface JsonOrderingState {
+  exactEncodingRequired: boolean;
+}
+
+const orderJsonObject = (value: Schema.Json, state: JsonOrderingState): Schema.Json => {
+  if (isJsonArray(value)) return value.map((entry) => orderJsonObject(entry, state));
+  if (!isJsonObject(value)) {
+    if (Predicate.isNumber(value) && !Number.isFinite(value)) encodeJson(value);
+    return value;
+  }
+
+  const ordered: Record<string, Schema.Json> = {};
+  const keys = Object.keys(value).sort();
+  for (const key of keys) {
+    const orderedEntry = orderJsonObject(jsonObjectEntry(value, key), state);
+    if (key === "__proto__") {
+      Object.defineProperty(ordered, key, {
+        configurable: true,
+        enumerable: true,
+        value: orderedEntry,
+        writable: true,
+      });
+    } else {
+      ordered[key] = orderedEntry;
+    }
+  }
+  if (!state.exactEncodingRequired) {
+    const runtimeKeys = Object.keys(ordered);
+    for (const [index, canonicalKey] of keys.entries()) {
+      if (runtimeKeys[index] !== canonicalKey) {
+        state.exactEncodingRequired = true;
+        break;
+      }
+    }
+  }
+  return ordered;
+};
 
 /** Encodes JSON with recursive UTF-16 object-key ordering. */
 export const canonicalJsonString = (value: Schema.Json): string => {
-  if (isJsonArray(value)) return `[${value.map(canonicalJsonString).join(",")}]`;
-  if (!isJsonObject(value)) return encodeJson(value);
-  return `{${Object.entries(value)
-    .sort(([left], [right]) => Order.String(left, right))
-    .map(([key, entry]) => `${encodeJson(key)}:${canonicalJsonString(entry)}`)
-    .join(",")}}`;
+  if (isJsonObject(value) && hasNativeKeyOrderConflict(value)) {
+    return canonicalJsonStringExact(value);
+  }
+  const state: JsonOrderingState = { exactEncodingRequired: false };
+  const ordered = orderJsonObject(value, state);
+  if (state.exactEncodingRequired) return canonicalJsonStringExact(ordered);
+  // oxlint-disable-next-line effect/noGlobals -- This serializer first establishes canonical object order. Native encoding avoids quadratic recursive string copies.
+  const encoded = JSON.stringify(ordered);
+  if (!Predicate.isString(encoded)) return encodeJson(value);
+  return encoded;
 };
 
 /** Computes the full lowercase SHA-256 digest of canonical JSON. */

--- a/src/internal/workflow-actor.ts
+++ b/src/internal/workflow-actor.ts
@@ -538,18 +538,21 @@ const layerPassthrough = <ROut, E, RIn>(
 ): Layer.Layer<ROut | RIn, E, RIn> =>
   Layer.merge(Layer.effectContext(Effect.context<RIn>()), layer);
 
+const makeWorkflowClientLayer = (actor: WorkflowActor<any, any, any, any>) =>
+  Layer.effect(
+    actor.Context,
+    Effect.map(WorkflowEngine, (engine) => {
+      const ref = buildWorkflowActorRef(actor, engine);
+      return (_entityId: string) => Effect.succeed(ref);
+    }),
+  );
+
 export const workflowToLayer = (
   actor: WorkflowActor<any, any, any, any>,
   handler: Function,
 ): Layer.Layer<any, any, any> => {
   const handlerLayer = actor._meta.workflow.toLayer(wrapWorkflowHandler(actor, handler) as any);
-  const clientLayer = Layer.effect(
-    actor.Context,
-    Effect.map(
-      WorkflowEngine,
-      (engine) => (_entityId: string) => Effect.succeed(buildWorkflowActorRef(actor, engine)),
-    ),
-  );
+  const clientLayer = makeWorkflowClientLayer(actor);
   return layerPassthrough(Layer.merge(handlerLayer, clientLayer));
 };
 
@@ -558,12 +561,6 @@ export const workflowToTestLayer = (
   handler: Function,
 ): Layer.Layer<any, any, any> => {
   const handlerLayer = actor._meta.workflow.toLayer(wrapWorkflowHandler(actor, handler) as any);
-  const clientLayer = Layer.effect(
-    actor.Context,
-    Effect.map(
-      WorkflowEngine,
-      (engine) => (_entityId: string) => Effect.succeed(buildWorkflowActorRef(actor, engine)),
-    ),
-  );
+  const clientLayer = makeWorkflowClientLayer(actor);
   return Layer.provideMerge(Layer.merge(handlerLayer, clientLayer), workflowEngineLayerMemory);
 };

--- a/test/canonical-json.test.ts
+++ b/test/canonical-json.test.ts
@@ -1,7 +1,18 @@
 import { BunCrypto } from "@effect/platform-bun";
 import { expect, it, test } from "effect-bun-test";
-import { Effect, type Schema } from "effect";
+import { Effect, Order, Schema } from "effect";
 import { canonicalJsonSha256, canonicalJsonString } from "../src/index.js";
+
+const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Json));
+
+const legacyCanonicalJsonString = (input: Schema.Json): string => {
+  if (Array.isArray(input)) return `[${input.map(legacyCanonicalJsonString).join(",")}]`;
+  if (!Schema.is(Schema.JsonObject)(input)) return encodeJson(input);
+  return `{${Object.entries(input)
+    .sort(([left], [right]) => Order.String(left, right))
+    .map(([key, entry]) => `${encodeJson(key)}:${legacyCanonicalJsonString(entry)}`)
+    .join(",")}}`;
+};
 
 const value: Schema.Json = {
   z: -0,
@@ -15,6 +26,104 @@ test("encodes canonical JSON with stable recursive key order", () => {
     '{"a":{"a":3,"😀":1,"￿":2},"list":[{"a":1,"b":2}],"z":0}',
   );
   expect(canonicalJsonString({ 2: 2, 10: 1 })).toBe('{"10":1,"2":2}');
+  expect(canonicalJsonString({ a: 1, 0: 0 })).toBe('{"0":0,"a":1}');
+  expect(canonicalJsonString({ 2: 2, 11: 11 })).toBe('{"11":11,"2":2}');
+  expect(canonicalJsonString({ "01": 1, 1: 1 })).toBe('{"01":1,"1":1}');
+});
+
+test("matches the previous encoder for representative JSON values", () => {
+  const protoKey = { z: 1 } satisfies Record<string, Schema.Json>;
+  Object.defineProperty(protoKey, "__proto__", {
+    configurable: true,
+    enumerable: true,
+    value: { b: 2, a: 1 },
+    writable: true,
+  });
+  /* oxlint-disable effect/noNullish -- JSON null is a required serializer input. */
+  const fixtures: ReadonlyArray<Schema.Json> = [
+    null,
+    true,
+    false,
+    0,
+    -0,
+    1.25,
+    1e100,
+    'line\nquote"slash\\emoji😀\ud800',
+    [3, { z: 1, a: 2 }, null],
+    { 2: 2, 10: 1, a: { y: true, x: false } },
+    protoKey,
+  ];
+  /* oxlint-enable effect/noNullish */
+
+  for (const fixture of fixtures) {
+    expect(canonicalJsonString(fixture)).toBe(legacyCanonicalJsonString(fixture));
+  }
+});
+
+test("matches the previous encoder across key-order classes", () => {
+  const keys = [
+    "",
+    "0",
+    "00",
+    "01",
+    "1",
+    "2",
+    "10",
+    "11",
+    "4294967294",
+    "4294967295",
+    "__proto__",
+    "a",
+    "😀",
+    "\uffff",
+  ];
+
+  for (const left of keys) {
+    for (const right of keys) {
+      if (left === right) continue;
+      const fixture: Record<string, Schema.Json> = {};
+      Object.defineProperty(fixture, left, {
+        enumerable: true,
+        value: { z: 1, a: 2 },
+      });
+      Object.defineProperty(fixture, right, {
+        enumerable: true,
+        value: [3, 2, 1],
+      });
+      const nested = { wrapper: [fixture] };
+      expect(canonicalJsonString(nested)).toBe(legacyCanonicalJsonString(nested));
+    }
+  }
+});
+
+test("handles deeply nested JSON without quadratic string copying", () => {
+  let nested: Schema.Json = 0;
+  for (let depth = 0; depth < 4_000; depth++) nested = { value: nested };
+
+  const encoded = canonicalJsonString(nested);
+  expect(encoded.length).toBe(40_001);
+  expect(encoded.startsWith('{"value":{"value":')).toBe(true);
+  expect(encoded.endsWith("}}".repeat(2_000))).toBe(true);
+});
+
+test("rejects non-finite numbers", () => {
+  expect(() => canonicalJsonString(Number.NaN)).toThrow();
+  expect(() => canonicalJsonString(Number.POSITIVE_INFINITY)).toThrow();
+});
+
+test("reads each object value once", () => {
+  let reads = 0;
+  const valueWithAccessor = { 2: 2, 10: 1 } satisfies Record<string, Schema.Json>;
+  Object.defineProperty(valueWithAccessor, "value", {
+    enumerable: true,
+    get: () => {
+      reads++;
+      return { z: 1, a: 2 };
+    },
+  });
+
+  expect(canonicalJsonString(valueWithAccessor)).toBe('{"10":1,"2":2,"value":{"a":2,"z":1}}');
+  expect(reads).toBe(1);
 });
 
 it.effect("computes the full SHA-256 digest of canonical JSON", () =>

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -228,4 +228,15 @@ describe("Actor.fromWorkflow — production layer", () => {
       expect(result).toBe("hello captured");
     }),
   );
+
+  it.scopedLive("reuses the layer-owned workflow client reference", () =>
+    Effect.gen(function* () {
+      const context = yield* Layer.build(ProductionLayer);
+      const client = Context.get(context, Greeter.Context);
+      const first = yield* client("first");
+      const second = yield* client("second");
+
+      expect(first).toBe(second);
+    }),
+  );
 });


### PR DESCRIPTION
## Problem / Intent

Canonical JSON encoding repeatedly validated each remaining subtree. It also copied each growing child string into every parent. Deep workflow payloads therefore had quadratic cost.

Workflow client factories also built the same immutable actor reference for every execution ID.

## Approach

Use constant-time JSON member checks. Build canonical object order once. Use native string encoding when property order is safe. Use an exact encoder for integer-key conflicts.

Build one workflow actor reference when the Effect layer starts. Return that reference from the existing Context service. Keep the public API and Effect context boundary unchanged.

Add repeatable benchmarks for canonical JSON, actor messages, and workflow messages. The final benchmark measures a 1,582.2x encoder speedup at depth 5,000. It measures a 17.6x end-to-end SHA-256 speedup on the nested fixture.

The actor benchmark measures execute at 6.3 microseconds. The actor reference factory costs 0.7 microseconds. A new cache would add mutable state and policy for a smaller cost. This change does not add that cache.

## Correctness

Canonical bytes match the old encoder across representative JSON values and 182 key-order cases. Tests cover integer keys, Unicode, primitive escaping, non-finite numbers, deep nesting, accessor reads, and SHA-256 output.

A workflow regression test proves that one layer owns one immutable client reference. The full gate passes with 282 tests and 702 checks.