### PR TITLE
fix: preserve schema payload identity

### DIFF
--- a/.changeset/attach-rpc-primary-key.md
+++ b/.changeset/attach-rpc-primary-key.md
@@ -1,0 +1,5 @@
+---
+"effect-encore": patch
+---
+
+Attach operation primary keys to schema-backed payloads without discarding their codecs.

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -58,6 +58,7 @@ import {
   makeOperationValue,
   payloadFromOperation,
   resolveId,
+  unwrapOpaquePayload,
 } from "./internal/invocation-compiler.js";
 import {
   waitFor as waitForExecution,
@@ -1492,7 +1493,7 @@ const transformHandlers = (
       transformed[tag] = (request: Record<string, unknown>) => {
         const raw = request["payload"];
         const buildOperation = (): Record<string, unknown> => {
-          if (opaque) return { _tag: tag, _payload: raw };
+          if (opaque) return { _tag: tag, _payload: unwrapOpaquePayload(raw) };
           return { _tag: tag, ...((raw ?? {}) as object) };
         };
         const operation = buildOperation();

--- a/src/internal/invocation-compiler.ts
+++ b/src/internal/invocation-compiler.ts
@@ -1,5 +1,5 @@
 import type { DateTime, Schema as SchemaType } from "effect";
-import { Context, Effect, Option, Predicate, PrimaryKey, Schema } from "effect";
+import { Context, Effect, Option, Predicate, PrimaryKey, Schema, SchemaGetter } from "effect";
 import {
   ClusterSchema,
   type Entity as ClusterEntity,
@@ -68,6 +68,29 @@ interface OperationIdentityBase {
 export const isOpaquePayload = <Payload>(payload: Payload): boolean =>
   Schema.isSchema(payload) && !Predicate.hasProperty(payload, "fields");
 
+/* oxlint-disable effect/noAs, effect/noChainedTypeAssertions, effect/noKnownValueWidening, effect/noNullish, effect/noRuntimeTypeof, effect/noTernary, effect/noUnknownParameters, effect/noUnsafeDictionaryType -- Effect Cluster erases schema-specific RPC types at this compiler seam. */
+
+const OpaquePayloadValue = Symbol("effect-encore/OpaquePayloadValue");
+
+export const unwrapOpaquePayload = (input: unknown): unknown => {
+  if (Predicate.hasProperty(input, OpaquePayloadValue)) {
+    const getter = input[OpaquePayloadValue];
+    if (typeof getter === "function") return Reflect.apply(getter, input, []);
+  }
+  return input;
+};
+
+const unwrapOpaquePayloadForEncoding = (input: unknown): unknown => {
+  const unwrapped = unwrapOpaquePayload(input);
+  if (unwrapped !== input) return unwrapped;
+  // Schema encoding validates the target class before it invokes the
+  // transformation. That validation can produce a plain object, so retain a
+  // structural fallback for the encode-side value.
+  return Predicate.isObject(input) && Predicate.hasProperty(input, "value")
+    ? input["value"]
+    : input;
+};
+
 export const resolveId = <Payload>(
   definition: OperationDef | void,
   payload: Payload,
@@ -105,7 +128,7 @@ export const payloadFromOperation = (
     isOpaquePayload(payloadSchema.value) &&
     Predicate.hasProperty(operation, "_payload")
   ) {
-    return operation["_payload"];
+    return unwrapOpaquePayload(operation["_payload"]);
   }
   return operation;
 };
@@ -133,43 +156,123 @@ export const compileInvocation = <Payload>(
   };
 };
 
-/* oxlint-disable effect/noAs, effect/noChainedTypeAssertions, effect/noKnownValueWidening, effect/noUnknownParameters, effect/noUnsafeDictionaryType -- Effect Cluster erases schema-specific RPC types at this compiler seam. */
+type PayloadClassBase = new (...args: ReadonlyArray<unknown>) => object;
+
+const makePayloadClass = (
+  base: Schema.Top,
+  primaryKeyOf: (input: unknown) => string,
+  deliverAt: ((input: unknown) => DateTime.DateTime) | undefined,
+  attachPrimaryKey: boolean,
+  opaque: boolean = false,
+): Schema.Top => {
+  class PayloadClass extends (base as unknown as PayloadClassBase) {}
+  const proto = PayloadClass.prototype as Record<string | symbol, unknown>;
+  if (opaque) {
+    proto[OpaquePayloadValue] = function (this: Record<string, unknown>) {
+      return this["value"];
+    };
+  }
+  if (attachPrimaryKey) {
+    proto[PrimaryKey.symbol] = function (this: unknown) {
+      return primaryKeyOf(unwrapOpaquePayload(this));
+    };
+  }
+  if (deliverAt) {
+    proto[DeliverAt.symbol] = function (this: unknown) {
+      return deliverAt(unwrapOpaquePayload(this));
+    };
+  }
+  return PayloadClass as unknown as Schema.Top;
+};
+
+const makeOpaquePayloadSchema = (
+  actorName: string,
+  tag: string,
+  payload: Schema.Top,
+  primaryKeyOf: (input: unknown) => string,
+  deliverAt: ((input: unknown) => DateTime.DateTime) | undefined,
+): Schema.Top => {
+  const Base = Schema.Class<Record<string, unknown>>(`effect-encore/${actorName}/${tag}/Payload`)({
+    value: Schema.Unknown,
+  });
+  const payloadClass = makePayloadClass(Base, primaryKeyOf, deliverAt, true, true);
+  const wrapped = Schema.decodeTo(payloadClass, {
+    decode: SchemaGetter.transform((input) => payloadClass.make({ value: input })),
+    encode: SchemaGetter.transform((input) => unwrapOpaquePayloadForEncoding(input)),
+  })(payload);
+
+  // The public constructor accepts the decoded user payload. The transformed
+  // schema itself stores the internal carrier so Envelope.primaryKey can read
+  // the cluster protocol before the original codec encodes the wire value.
+  (wrapped as Schema.Top).make = (input, options) => payloadClass.make({ value: input }, options);
+  return wrapped;
+};
+
+const compileSchemaPayload = (
+  actorName: string,
+  tag: string,
+  payload: Schema.Top,
+  primaryKeyOf: (input: unknown) => string,
+  deliverAt: ((input: unknown) => DateTime.DateTime) | undefined,
+): Schema.Top => {
+  if (Predicate.hasProperty(payload, "fields")) {
+    const hasPrimaryKey =
+      Predicate.hasProperty(payload, "prototype") &&
+      Predicate.hasProperty(payload["prototype"], PrimaryKey.symbol);
+    const hasDeliverAt =
+      Predicate.hasProperty(payload, "prototype") &&
+      Predicate.hasProperty(payload["prototype"], DeliverAt.symbol);
+
+    if (hasPrimaryKey && (!deliverAt || hasDeliverAt)) return payload;
+
+    let base: Schema.Top;
+    let preserveSchema = false;
+    let payloadDeliverAt = deliverAt;
+    if (Predicate.hasProperty(payload, "identifier")) {
+      base = payload;
+    } else {
+      base = Schema.Class<Record<string, unknown>>(`effect-encore/${actorName}/${tag}/Payload`)(
+        payload["fields"] as Schema.Struct.Fields,
+      );
+      preserveSchema = true;
+    }
+    if (hasDeliverAt) payloadDeliverAt = undefined;
+    const payloadClass = makePayloadClass(base, primaryKeyOf, payloadDeliverAt, !hasPrimaryKey);
+    if (preserveSchema) return Schema.decodeTo(payloadClass)(payload);
+    return payloadClass;
+  }
+
+  // Opaque payloads (for example Schema.String) have no object prototype on
+  // on which the cluster protocol can be attached. This also covers
+  // transformed schemas whose decoded value is an object or class: the
+  // original decoded value stays inside the carrier and reaches user code
+  // unchanged after the transport unwraps it.
+  return makeOpaquePayloadSchema(actorName, tag, payload, primaryKeyOf, deliverAt);
+};
 
 export const compileRpc = (actorName: string, tag: string, def: OperationDef): Rpc.Any => {
   const options: Record<string, unknown> = {};
   const payload = def["payload"];
-  const deliverAt = def["deliverAt"];
+  const deliverAt = def["deliverAt"] as ((input: unknown) => DateTime.DateTime) | undefined;
   const primaryKeyOf = (input: unknown) => resolveId(def, input, tag).primaryKey;
 
   if (payload) {
     if (Schema.isSchema(payload)) {
-      options["payload"] = payload;
+      options["payload"] = compileSchemaPayload(actorName, tag, payload, primaryKeyOf, deliverAt);
     } else {
       const Base = Schema.Class<Record<string, unknown>>(
         `effect-encore/${actorName}/${tag}/Payload`,
       )(payload);
-      class PayloadClass extends Base {}
-      const proto = PayloadClass.prototype as Record<string | symbol, unknown>;
-      proto[PrimaryKey.symbol] = function (this: unknown) {
-        return primaryKeyOf(this);
-      };
-      if (deliverAt) {
-        proto[DeliverAt.symbol] = function (this: unknown) {
-          return (deliverAt as Function)(this) as DateTime.DateTime;
-        };
-      }
-      options["payload"] = PayloadClass;
+      const payloadClass = makePayloadClass(Base, primaryKeyOf, deliverAt, true);
+      options["payload"] = payloadClass;
     }
   } else {
     const Base = Schema.Class<Record<string, unknown>>(`effect-encore/${actorName}/${tag}/Payload`)(
       {},
     );
-    class EmptyPayloadClass extends Base {}
-    (EmptyPayloadClass.prototype as Record<string | symbol, unknown>)[PrimaryKey.symbol] =
-      function () {
-        return primaryKeyOf(Schema.Void.make());
-      };
-    options["payload"] = EmptyPayloadClass;
+    const emptyPrimaryKeyOf = (_input: unknown) => primaryKeyOf(Schema.Void.make());
+    const payloadClass = makePayloadClass(Base, emptyPrimaryKeyOf, undefined, true);
+    options["payload"] = payloadClass;
   }
 
   if (def["success"]) options["success"] = def["success"];
@@ -235,7 +338,7 @@ export const compileOutgoingRequest = (
     if (!definition.payload) {
       payload = payloadSchema.make({});
     } else if (isOpaquePayload(definition.payload)) {
-      payload = operation["_payload"];
+      payload = payloadSchema.make(operation["_payload"]);
     } else {
       const { _tag: operationTag, ...fields } = operation;
       void operationTag;
@@ -264,4 +367,4 @@ export const compileOutgoingRequest = (
     });
   });
 
-/* oxlint-enable effect/noAs, effect/noChainedTypeAssertions, effect/noKnownValueWidening, effect/noUnknownParameters, effect/noUnsafeDictionaryType */
+/* oxlint-enable effect/noAs, effect/noChainedTypeAssertions, effect/noKnownValueWidening, effect/noNullish, effect/noRuntimeTypeof, effect/noTernary, effect/noUnknownParameters, effect/noUnsafeDictionaryType */

--- a/test/actor.test.ts
+++ b/test/actor.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, test } from "effect-bun-test";
-import { Context, DateTime, Effect, Layer, PrimaryKey, Schema } from "effect";
+import { Context, DateTime, Effect, Layer, PrimaryKey, Schema, SchemaGetter } from "effect";
 import { ClusterSchema, ShardingConfig } from "effect/unstable/cluster";
 import * as DeliverAt from "effect/unstable/cluster/DeliverAt";
 import { Actor } from "../src/index.js";
+import { unwrapOpaquePayload } from "../src/internal/invocation-compiler.js";
 
 // Fixed instant: these cases assert DeliverAt/PrimaryKey wiring, not the clock.
 const FIXED_EPOCH_MS = 1_700_000_000_000;
@@ -261,9 +262,177 @@ describe("scalar payload", () => {
       expect(String(execId)).toBe("test\x00Say\x00test");
     }),
   );
+
+  test("preserves opaque scalar codecs while attaching a primary key carrier", () => {
+    const rpc = Echo._meta.entity.protocol.requests.get("Say")!;
+    const instance = rpc.payloadSchema.make("hello");
+    expect(PrimaryKey.isPrimaryKey(instance)).toBe(true);
+    if (PrimaryKey.isPrimaryKey(instance)) {
+      expect(PrimaryKey.value(instance)).toBe("hello");
+    }
+    expect(Schema.encodeUnknownSync(rpc.payloadSchema)(instance)).toBe("hello");
+    const decoded = Schema.decodeSync(rpc.payloadSchema)("decoded");
+    expect(PrimaryKey.isPrimaryKey(decoded)).toBe(true);
+    if (PrimaryKey.isPrimaryKey(decoded)) {
+      expect(PrimaryKey.value(decoded)).toBe("decoded");
+    }
+  });
+
+  test("attaches identity to opaque object-union schemas", () => {
+    const UnionActor = Actor.fromEntity("UnionPayload", {
+      Run: {
+        payload: Schema.Union([Schema.String, Schema.Struct({ id: Schema.String })]),
+        id: (payload: string | { readonly id: string }) => {
+          if (Schema.is(Schema.String)(payload)) return payload;
+          return payload.id;
+        },
+      },
+    });
+    const rpc = UnionActor._meta.entity.protocol.requests.get("Run")!;
+    const scalar = rpc.payloadSchema.make("union-scalar");
+    const object = rpc.payloadSchema.make({ id: "union-object" });
+
+    expect(PrimaryKey.isPrimaryKey(scalar)).toBe(true);
+    expect(PrimaryKey.isPrimaryKey(object)).toBe(true);
+    if (PrimaryKey.isPrimaryKey(scalar) && PrimaryKey.isPrimaryKey(object)) {
+      expect(PrimaryKey.value(scalar)).toBe("union-scalar");
+      expect(PrimaryKey.value(object)).toBe("union-object");
+    }
+    expect(Schema.encodeUnknownSync(rpc.payloadSchema)(scalar)).toBe("union-scalar");
+    expect(Schema.encodeUnknownSync(rpc.payloadSchema)(object)).toEqual({ id: "union-object" });
+  });
 });
 
 describe("deliverAt", () => {
+  test("attaches PrimaryKey.symbol to schema payload instances", () => {
+    const WithSchemaPayload = Actor.fromEntity("WithSchemaPayload", {
+      Op: {
+        payload: Schema.Struct({ id: Schema.String }),
+        id: (payload: { readonly id: string }) => payload.id,
+      },
+    });
+
+    const rpc = WithSchemaPayload._meta.entity.protocol.requests.get("Op")!;
+    const instance = rpc.payloadSchema.make({ id: "schema-abc" });
+
+    expect(PrimaryKey.isPrimaryKey(instance)).toBe(true);
+    if (PrimaryKey.isPrimaryKey(instance)) {
+      expect(PrimaryKey.value(instance)).toBe("schema-abc");
+    }
+  });
+
+  test("preserves transformed schema payload codecs while adding identity", () => {
+    const DecodedPayload = Schema.Struct({
+      id: Schema.String,
+      value: Schema.String,
+    }).pipe(
+      Schema.decodeTo(Schema.Struct({ id: Schema.String, value: Schema.Finite }), {
+        decode: SchemaGetter.transform((payload) => ({
+          id: payload.id,
+          value: Number(payload.value),
+        })),
+        encode: SchemaGetter.transform((payload) => ({
+          id: payload.id,
+          value: String(payload.value),
+        })),
+      }),
+    );
+    const WithDecodedPayload = Actor.fromEntity("WithDecodedPayload", {
+      Op: {
+        payload: DecodedPayload,
+        id: (payload: { readonly id: string; readonly value: number }) => payload.id,
+      },
+    });
+
+    const rpc = WithDecodedPayload._meta.entity.protocol.requests.get("Op")!;
+    const decodedCarrier = Schema.decodeSync(rpc.payloadSchema)({
+      id: "decoded-abc",
+      value: "42",
+    });
+    const decoded = Schema.decodeUnknownSync(
+      Schema.Struct({ id: Schema.String, value: Schema.Finite }),
+    )(unwrapOpaquePayload(decodedCarrier));
+    const encoded = Schema.encodeUnknownSync(rpc.payloadSchema)(decodedCarrier);
+
+    expect(decoded.value).toBe(42);
+    expect(encoded).toEqual({ id: "decoded-abc", value: "42" });
+    expect(PrimaryKey.isPrimaryKey(decodedCarrier)).toBe(true);
+    if (PrimaryKey.isPrimaryKey(decodedCarrier)) {
+      expect(PrimaryKey.value(decodedCarrier)).toBe("decoded-abc");
+    }
+  });
+
+  it.scopedLive("preserves transformed Schema.Class methods while adding identity", () => {
+    class DecodedPayload extends Schema.Class<DecodedPayload>("test/DecodedPayload")({
+      id: Schema.String,
+    }) {
+      key(): string {
+        return this.id;
+      }
+    }
+    const EncodedPayload = Schema.String.pipe(
+      Schema.decodeTo(DecodedPayload, {
+        decode: SchemaGetter.transform((id) => DecodedPayload.make({ id })),
+        encode: SchemaGetter.transform((payload) => payload.id),
+      }),
+    );
+    const WithDecodedClass = Actor.fromEntity("WithDecodedClass", {
+      Run: {
+        payload: EncodedPayload,
+        success: Schema.String,
+        id: (payload: DecodedPayload) => payload.key(),
+      },
+    });
+    const rpc = WithDecodedClass._meta.entity.protocol.requests.get("Run")!;
+    const decodedCarrier = Schema.decodeSync(rpc.payloadSchema)("class-roundtrip");
+    const decoded = Schema.decodeUnknownSync(DecodedPayload)(unwrapOpaquePayload(decodedCarrier));
+
+    expect(Schema.is(DecodedPayload)(decoded)).toBe(true);
+    expect(decoded.key()).toBe("class-roundtrip");
+    expect(PrimaryKey.isPrimaryKey(decodedCarrier)).toBe(true);
+    if (PrimaryKey.isPrimaryKey(decodedCarrier)) {
+      expect(PrimaryKey.value(decodedCarrier)).toBe("class-roundtrip");
+    }
+    expect(Schema.encodeUnknownSync(rpc.payloadSchema)(decodedCarrier)).toBe("class-roundtrip");
+
+    const HandlerLayer = Layer.provide(
+      Actor.toTestLayer(WithDecodedClass, {
+        Run: ({ operation }) =>
+          Effect.succeed(
+            `${operation._payload.key()}:${Schema.is(DecodedPayload)(operation._payload)}`,
+          ),
+      }),
+      TestShardingConfig,
+    );
+    return Effect.gen(function* () {
+      const result = yield* WithDecodedClass.Run.execute(DecodedPayload.make({ id: "handler" }));
+      expect(result).toBe("handler:true");
+    }).pipe(Effect.provide(HandlerLayer));
+  });
+
+  test("attaches both identity protocols to schema payload instances", () => {
+    const WithSchemaDelivery = Actor.fromEntity("WithSchemaDelivery", {
+      Op: {
+        payload: Schema.Struct({ id: Schema.String, when: Schema.DateTimeUtc }),
+        id: (payload: { readonly id: string }) => payload.id,
+        deliverAt: (payload: { readonly when: DateTime.DateTime }) => payload.when,
+      },
+    });
+
+    const rpc = WithSchemaDelivery._meta.entity.protocol.requests.get("Op")!;
+    const when = DateTime.makeUnsafe(FIXED_EPOCH_MS);
+    const instance = rpc.payloadSchema.make({ id: "schema-delivery", when });
+
+    expect(PrimaryKey.isPrimaryKey(instance)).toBe(true);
+    expect(DeliverAt.isDeliverAt(instance)).toBe(true);
+    if (PrimaryKey.isPrimaryKey(instance)) {
+      expect(PrimaryKey.value(instance)).toBe("schema-delivery");
+    }
+    if (DeliverAt.isDeliverAt(instance)) {
+      expect(DeliverAt.toMillis(instance)).toBe(FIXED_EPOCH_MS);
+    }
+  });
+
   test("attaches DeliverAt.symbol to payload instances when deliverAt is configured", () => {
     const Delayed = Actor.fromEntity("Delayed", {
       Process: {
@@ -350,6 +519,37 @@ describe("deliverAt", () => {
 
     expect(instance[PrimaryKey.symbol]()).toBe("xyz");
     expect(rpc.payloadSchema).toBe(CustomPayload);
+  });
+
+  test("preserves Schema.Class methods while adding identity protocols", () => {
+    class ClassWithoutProtocols extends Schema.Class<ClassWithoutProtocols>(
+      "test/ClassWithoutProtocols",
+    )({
+      id: Schema.String,
+    }) {
+      describe(): string {
+        return `payload:${this.id}`;
+      }
+    }
+
+    const WithClass = Actor.fromEntity("WithClass", {
+      Process: {
+        payload: ClassWithoutProtocols,
+        id: (p: { id: string }) => p.id,
+      },
+    });
+    const rpc = WithClass._meta.entity.protocol.requests.get("Process")!;
+    const instance = rpc.payloadSchema.make({ id: "class-make" });
+    const decoded = Schema.decodeSync(rpc.payloadSchema)({ id: "class-decode" });
+
+    expect(instance.describe()).toBe("payload:class-make");
+    expect(decoded.describe()).toBe("payload:class-decode");
+    expect(PrimaryKey.isPrimaryKey(instance)).toBe(true);
+    expect(PrimaryKey.isPrimaryKey(decoded)).toBe(true);
+    if (PrimaryKey.isPrimaryKey(instance) && PrimaryKey.isPrimaryKey(decoded)) {
+      expect(PrimaryKey.value(instance)).toBe("class-make");
+      expect(PrimaryKey.value(decoded)).toBe("class-decode");
+    }
   });
 
   test("pre-built Schema.Class with DeliverAt works", () => {

--- a/test/client-layer.test.ts
+++ b/test/client-layer.test.ts
@@ -21,9 +21,12 @@ import { describe, expect, it } from "effect-bun-test";
 import { Cause, Context, Effect, Exit, Layer, Option, Ref, Schema } from "effect";
 import type { Entity as ClusterEntity } from "effect/unstable/cluster";
 import { Entity, MessageStorage, ShardingConfig, TestRunner } from "effect/unstable/cluster";
+import { SqlClient } from "effect/unstable/sql";
+import { BunCrypto } from "@effect/platform-bun";
+import { SqliteClient } from "@effect/sql-sqlite-bun";
 import type { ActorMailboxService } from "../src/actor-mailbox.js";
 import { ActorMailbox, MailboxError } from "../src/actor-mailbox.js";
-import { Actor, Client, ClientLayer } from "../src/index.js";
+import { Actor, Client, ClientLayer, fromSqlClient } from "../src/index.js";
 import { makeTestMailboxImpl } from "../src/client.js";
 import { compileInvocation } from "../src/internal/invocation-compiler.js";
 
@@ -46,6 +49,21 @@ const ClientActor = Actor.fromEntity("ClientLayerActor", {
   },
 });
 
+const SchemaPayloadClientActor = Actor.fromEntity("SchemaPayloadClientLayerActor", {
+  Process: {
+    payload: Schema.Struct({ input: Schema.String }),
+    success: Schema.String,
+    persisted: true,
+    id: (p: { input: string }) => p.input,
+  },
+  Scalar: {
+    payload: Schema.String,
+    success: Schema.String,
+    persisted: true,
+    id: (p: string) => p,
+  },
+});
+
 // A live-only (non-persisted) op to exercise the persisted gate.
 const LiveOnlyActor = Actor.fromEntity("ClientLayerLiveOnly", {
   Ping: {
@@ -63,9 +81,17 @@ const processEntity = ClientActor._meta.entity as ClusterEntity.Entity<string, a
 // eslint-disable-next-line typescript-eslint/no-explicit-any
 // oxlint-disable-next-line effect/noAs -- the Client transport seam erases the invariant entity name and RPC union
 const liveOnlyEntity = LiveOnlyActor._meta.entity as ClusterEntity.Entity<string, any>;
+// eslint-disable-next-line typescript-eslint/no-explicit-any -- entity name param is invariant
+// oxlint-disable-next-line effect/noAs -- the Client transport seam erases the invariant entity name and RPC union
+const schemaPayloadEntity = SchemaPayloadClientActor._meta.entity as ClusterEntity.Entity<
+  string,
+  any
+>;
 
 const processDefs = ClientActor._meta.internalDefinitions ?? ClientActor._meta.definitions;
 const liveOnlyDefs = LiveOnlyActor._meta.internalDefinitions ?? LiveOnlyActor._meta.definitions;
+const schemaPayloadDefs =
+  SchemaPayloadClientActor._meta.internalDefinitions ?? SchemaPayloadClientActor._meta.definitions;
 
 const processInvocation = (input: string) =>
   compileInvocation(processEntity, "Process", processDefs["Process"], { input });
@@ -73,6 +99,10 @@ const failInvocation = (input: string) =>
   compileInvocation(processEntity, "Fail", processDefs["Fail"], { input });
 const pingInvocation = (input: string) =>
   compileInvocation(liveOnlyEntity, "Ping", liveOnlyDefs["Ping"], { input });
+const schemaPayloadInvocation = (input: string) =>
+  compileInvocation(schemaPayloadEntity, "Process", schemaPayloadDefs["Process"], { input });
+const scalarPayloadInvocation = (input: string) =>
+  compileInvocation(schemaPayloadEntity, "Scalar", schemaPayloadDefs["Scalar"], input);
 
 // ── Client.layer.memory — self-contained producer (no consumer) ────────────
 
@@ -129,6 +159,15 @@ const FromConfigStorage = MessageStorage.layerMemory.pipe(
   Layer.provideMerge(ShardingConfig.layer()),
 );
 
+const SqlStorage = fromSqlClient().pipe(
+  Layer.provideMerge(SqliteClient.layer({ filename: ":memory:" })),
+  Layer.provide(BunCrypto.layer),
+);
+const SqlClientLayer = ClientLayer.fromConfig.pipe(
+  Layer.provideMerge(SqlStorage),
+  Layer.provideMerge(ShardingConfig.layer()),
+);
+
 describe("Client.layer.fromConfig", () => {
   it.scopedLive("persisted send lands in the explicitly-provided storage", () =>
     Effect.gen(function* () {
@@ -139,6 +178,36 @@ describe("Client.layer.fromConfig", () => {
       const unprocessed = yield* storage.unprocessedMessages([address.shardId]);
       expect(unprocessed.length).toBeGreaterThan(0);
     }).pipe(Effect.provide(ClientLayer.fromConfig.pipe(Layer.provideMerge(FromConfigStorage)))),
+  );
+
+  it.scopedLive("public send deduplicates schema payloads in SQL storage", () =>
+    Effect.gen(function* () {
+      const client = yield* Client;
+      const sql = yield* SqlClient.SqlClient;
+      yield* client.send(schemaPayloadInvocation("sql-public-dup"));
+      yield* client.send(schemaPayloadInvocation("sql-public-dup"));
+      yield* client.send(scalarPayloadInvocation("sql-scalar-dup"));
+      yield* client.send(scalarPayloadInvocation("sql-scalar-dup"));
+
+      const rows = yield* sql<{ readonly count: number | bigint }>`
+        SELECT COUNT(*) AS count
+        FROM cluster_messages
+        WHERE entity_type = ${schemaPayloadEntity.type}
+          AND entity_id = ${"sql-public-dup"}
+          AND tag = ${"Process"}
+      `;
+      const scalarRows = yield* sql<{ readonly count: number | bigint }>`
+        SELECT COUNT(*) AS count
+        FROM cluster_messages
+        WHERE entity_type = ${schemaPayloadEntity.type}
+          AND entity_id = ${"sql-scalar-dup"}
+          AND tag = ${"Scalar"}
+      `;
+      expect(rows).toHaveLength(1);
+      expect(String(rows[0]?.count)).toBe("1");
+      expect(scalarRows).toHaveLength(1);
+      expect(String(scalarRows[0]?.count)).toBe("1");
+    }).pipe(Effect.provide(SqlClientLayer)),
   );
 });
 

--- a/test/mailbox.test.ts
+++ b/test/mailbox.test.ts
@@ -14,8 +14,11 @@
  *    storage that a consumer's poll loop reads from, exercising the path that
  *    motivated this work.
  */
+import { SqliteClient } from "@effect/sql-sqlite-bun";
+import { BunCrypto } from "@effect/platform-bun";
 import { describe, expect, it } from "effect-bun-test";
 import { Cause, Context, Effect, Exit, Layer, Option, Schema } from "effect";
+import { SqlClient } from "effect/unstable/sql";
 import type { Entity as ClusterEntity } from "effect/unstable/cluster";
 import {
   EntityAddress,
@@ -32,13 +35,22 @@ import * as Headers from "effect/unstable/http/Headers";
 import type { Rpc } from "effect/unstable/rpc";
 import { ActorAddressResolver, ActorAddressResolverLayer } from "../src/actor-address-resolver.js";
 import { ActorMailbox, ActorMailboxLayer, MailboxError } from "../src/actor-mailbox.js";
-import { Actor } from "../src/index.js";
+import { Actor, fromSqlClient } from "../src/index.js";
 
 // Two actors: one persisted, one not. The persisted one round-trips through
 // fromConfig; the non-persisted one MUST be rejected.
 const PersistedActor = Actor.fromEntity("MailboxPersistedActor", {
   Place: {
     payload: { item: Schema.String },
+    success: Schema.String,
+    persisted: true,
+    id: (p: { item: string }) => p.item,
+  },
+});
+
+const SchemaPayloadActor = Actor.fromEntity("MailboxSchemaPayloadActor", {
+  Place: {
+    payload: Schema.Struct({ item: Schema.String }),
     success: Schema.String,
     persisted: true,
     id: (p: { item: string }) => p.item,
@@ -58,7 +70,7 @@ const LiveOnlyActor = Actor.fromEntity("MailboxLiveOnlyActor", {
 // internal `OperationHandle.send` plumbing. Mirrors the Invocation compiler
 // in actor.ts but inlined here for unit-test clarity.
 const buildRequest = (
-  actor: typeof PersistedActor | typeof LiveOnlyActor,
+  actor: typeof PersistedActor | typeof SchemaPayloadActor | typeof LiveOnlyActor,
   tag: string,
   payload: { readonly item: string } | { readonly input: string },
 ): Effect.Effect<Message.OutgoingRequest<Rpc.Any>, never, Snowflake.Generator> =>
@@ -113,6 +125,15 @@ const TestStack = ActorMailboxLayer.fromConfig.pipe(
   Layer.provideMerge(Snowflake.layerGenerator),
 );
 
+const SqlStorageLayer = fromSqlClient().pipe(
+  Layer.provideMerge(SqliteClient.layer({ filename: ":memory:" })),
+  Layer.provide(BunCrypto.layer),
+);
+const SqlTestStack = ActorMailboxLayer.fromConfig.pipe(
+  Layer.provideMerge(SqlStorageLayer),
+  Layer.provideMerge(Snowflake.layerGenerator),
+);
+
 describe("ActorMailboxLayer.fromConfig", () => {
   it.scopedLive("rejects non-persisted requests with MailboxError", () =>
     Effect.gen(function* () {
@@ -154,6 +175,41 @@ describe("ActorMailboxLayer.fromConfig", () => {
       const exit = yield* mailbox.send(b).pipe(Effect.exit);
       expect(Exit.isSuccess(exit)).toBe(true);
     }).pipe(Effect.provide(TestStack)),
+  );
+
+  it.scopedLive("deduplicates schema payloads using the operation identity", () =>
+    Effect.gen(function* () {
+      const mailbox = yield* ActorMailbox;
+      const a = yield* buildRequest(SchemaPayloadActor, "Place", { item: "schema-dup" });
+      const b = yield* buildRequest(SchemaPayloadActor, "Place", { item: "schema-dup" });
+      yield* mailbox.send(a);
+      const exit = yield* mailbox.send(b).pipe(Effect.exit);
+      expect(Exit.isSuccess(exit)).toBe(true);
+      const storage = yield* MessageStorage.MessageStorage;
+      const unprocessed = yield* storage.unprocessedMessages([a.envelope.address.shardId]);
+      expect(unprocessed).toHaveLength(1);
+    }).pipe(Effect.provide(TestStack)),
+  );
+
+  it.scopedLive("deduplicates schema payloads in SQL mailbox storage", () =>
+    Effect.gen(function* () {
+      const mailbox = yield* ActorMailbox;
+      const sql = yield* SqlClient.SqlClient;
+      const a = yield* buildRequest(SchemaPayloadActor, "Place", { item: "sql-schema-dup" });
+      const b = yield* buildRequest(SchemaPayloadActor, "Place", { item: "sql-schema-dup" });
+      yield* mailbox.send(a);
+      yield* mailbox.send(b);
+
+      const rows = yield* sql<{ readonly count: number | bigint }>`
+        SELECT COUNT(*) AS count
+        FROM cluster_messages
+        WHERE entity_type = ${a.envelope.address.entityType}
+          AND entity_id = ${a.envelope.address.entityId}
+          AND tag = ${a.envelope.tag}
+      `;
+      expect(rows).toHaveLength(1);
+      expect(String(rows[0]?.count)).toBe("1");
+    }).pipe(Effect.provide(SqlTestStack)),
   );
 });
 


### PR DESCRIPTION
## Summary
Attach durable primary-key identity to schema-backed operation payloads while preserving codecs and public handler values.

## Changes
- Preserve identity for struct, scalar, union, and transformed schema payloads.
- Preserve transformed Schema.Class values and methods at the public handler boundary.
- Add real SQL mailbox and public Client duplicate-send coverage.
- Add the patch Changeset.

## Test Plan
- `bun run gate`
- 296 tests, 747 assertions
- Typecheck, lint, format, and build pass

Root review approved this release unit.