### PR TITLE
fix(actor): omit entity-scoped services from captured layer build context

### DIFF
--- a/.changeset/nested-layer-build-context.md
+++ b/.changeset/nested-layer-build-context.md
@@ -1,0 +1,5 @@
+---
+"effect-encore": patch
+---
+
+`provideLayerBuildContext` no longer captures `CurrentAddress`, `CurrentRunnerAddress`, `ActorStateRegistry`, or `Scope` from the layer-build fiber. An actor layer built inside another actor's handler previously read the outer entity's address in its handler build.

--- a/src/actor.ts
+++ b/src/actor.ts
@@ -7,7 +7,7 @@ import {
   type ShardingConfig,
   Snowflake,
 } from "effect/unstable/cluster";
-import { CurrentAddress, type CurrentRunnerAddress } from "effect/unstable/cluster/Entity";
+import { CurrentAddress, CurrentRunnerAddress } from "effect/unstable/cluster/Entity";
 import type {
   AlreadyProcessingMessage,
   EntityNotAssignedToRunner,
@@ -32,9 +32,10 @@ import {
   Pipeable,
   Predicate,
   Schema,
+  Scope,
   Stream,
 } from "effect";
-import type { Schedule, Scope } from "effect";
+import type { Schedule } from "effect";
 import { dual } from "effect/Function";
 import type { SignalDefs, WorkflowStepContext } from "./step.js";
 import type { ExecId, PeekResult } from "./receipt.js";
@@ -471,8 +472,32 @@ export const provideLayerBuildContext = <A, E, R>(
   Exclude<R, ActorLayerBuildContextExclusions>
 > =>
   Effect.context<Exclude<R, ActorLayerBuildContextExclusions>>().pipe(
-    Effect.map((context) => provideCapturedLayerBuildContext(build, context)),
+    Effect.map((context) =>
+      provideCapturedLayerBuildContext(build, omitLayerBuildContextExclusions(context)),
+    ),
   );
+
+/**
+ * The layer-build context is captured wherever the actor layer is built. When
+ * that happens inside another actor's handler (a nested composition root), the
+ * fiber context carries that outer actor's `CurrentAddress`, runner address,
+ * state registry, and scope. Those must not shadow the values the entity
+ * manager provides to the handler build, or the inner actor would read the
+ * outer entity's identity.
+ */
+function omitLayerBuildContextExclusions<R>(
+  context: Context.Context<Exclude<R, ActorLayerBuildContextExclusions>>,
+): Context.Context<Exclude<R, ActorLayerBuildContextExclusions>>;
+function omitLayerBuildContextExclusions<R>(
+  context: Context.Context<Exclude<R, ActorLayerBuildContextExclusions>>,
+): unknown {
+  return Context.omit(
+    Scope.Scope,
+    CurrentAddress,
+    CurrentRunnerAddress,
+    ActorStateRegistry,
+  )(context);
+}
 
 /**
  * Typed state declaration for an entity. When supplied via `fromEntity`'s

--- a/test/actor-with-scope.test.ts
+++ b/test/actor-with-scope.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "effect-bun-test";
 import { Context, Effect, Layer, Schema } from "effect";
-import { ShardingConfig } from "effect/unstable/cluster";
+import {
+  EntityAddress,
+  EntityId,
+  EntityType,
+  ShardId,
+  ShardingConfig,
+} from "effect/unstable/cluster";
+import { CurrentAddress } from "effect/unstable/cluster/Entity";
 import { Actor } from "../src/index.js";
 
 const TestShardingConfig = ShardingConfig.layer({
@@ -71,6 +78,36 @@ const CapturedLayer = Layer.provide(
   Layer.merge(TestShardingConfig, Layer.succeed(LayerToken, "captured-layer-token")),
 );
 
+const Nested = Actor.fromEntity("Nested", {
+  WhoAmI: {
+    payload: { id: Schema.String },
+    success: Schema.String,
+    id: (p: { id: string }) => p.id,
+  },
+});
+
+// Models an actor layer built inside another actor's handler: the fiber
+// context at layer-build time already carries an outer `CurrentAddress`.
+const outerAddress = EntityAddress.make({
+  shardId: ShardId.make("default", 1),
+  entityType: EntityType.make("Outer"),
+  entityId: EntityId.make("outer-entity"),
+});
+
+const NestedLayer = Layer.provide(
+  Layer.unwrap(
+    Actor.provideLayerBuildContext(
+      Effect.gen(function* () {
+        const address = yield* CurrentAddress;
+        return Nested.of({
+          WhoAmI: () => Effect.succeed(address.entityId),
+        });
+      }),
+    ).pipe(Effect.map((build) => Actor.toTestLayer(Nested, build))),
+  ),
+  Layer.merge(TestShardingConfig, Layer.succeed(CurrentAddress, outerAddress)),
+);
+
 const DynamicLayer = Layer.provide(
   Actor.toTestLayer(
     Dynamic,
@@ -84,6 +121,7 @@ const DynamicLayer = Layer.provide(
 const scopedTest = it.scopedLive.layer(ScopedLayer);
 const capturedTest = it.scopedLive.layer(CapturedLayer);
 const dynamicTest = it.scopedLive.layer(DynamicLayer);
+const nestedTest = it.scopedLive.layer(NestedLayer);
 
 describe("Actor.toLayer({ withScope })", () => {
   scopedTest("handler reads a Tag built per-call from the entity address", () =>
@@ -114,6 +152,17 @@ describe("Actor.toLayer({ withScope })", () => {
       const value = yield* ref.execute(Captured.Read.make({ id: "alpha" }));
       expect(value).toBe("captured-layer-token");
     }),
+  );
+
+  nestedTest(
+    "handler build keeps its own entity address when the layer is built inside another actor",
+    () =>
+      Effect.gen(function* () {
+        const makeRef = yield* Nested.Context;
+        const ref = yield* makeRef("inner-entity");
+        const value = yield* ref.execute(Nested.WhoAmI.make({ id: "inner-entity" }));
+        expect(value).toBe("inner-entity");
+      }),
   );
 
   dynamicTest("caller-provided services override actor layer services", () =>


### PR DESCRIPTION
`provideLayerBuildContext` captured the whole layer-build fiber context. An actor layer built inside another actor's handler read the outer entity's `CurrentAddress` in its handler build. Omit the declared `ActorLayerBuildContextExclusions` at capture time. Regression test in `test/actor-with-scope.test.ts`.

https://claude.ai/code/session_01NPv6L9S8MBxccNnpyjhANc