### PR TITLE
feat(actor-state): export the state registry from the package root

### DIFF
--- a/.changeset/lucky-pugs-cheer.md
+++ b/.changeset/lucky-pugs-cheer.md
@@ -1,0 +1,18 @@
+---
+"effect-encore": minor
+---
+
+Export `ActorStateRegistry` and its query functions from the package root
+
+`Actor.toLayer` merges `ActorStateRegistry.Live` into the consumer's context, so
+the registry was already reachable at runtime — but the Tag was not exported,
+leaving no way to name it.
+
+That left the actor's own `State` client as the only route to enumerate live
+entities, which is unusable from anything built _beneath_ the actor: requiring
+`ActorStateClientService<Name>` there makes the layer that builds the actor
+depend on the actor it builds.
+
+Now exported: `ActorStateRegistry`, `ActorStateRegistryService`,
+`listStateEntityIds`, `stateOf`, `watchStateOf`, and `waitForStateOf`. The
+decode plumbing (`makeActorStateObservation`) stays internal.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,14 @@
 export { Actor, CurrentAddress, fromRpcs, SendAndAwaitTimeout, withProtocol } from "./actor.js";
-export { ActorStateUnavailable, registerState } from "./actor-state.js";
+export {
+  ActorStateRegistry,
+  ActorStateUnavailable,
+  listStateEntityIds,
+  registerState,
+  stateOf,
+  waitForStateOf,
+  watchStateOf,
+} from "./actor-state.js";
+export type { ActorStateRegistryService } from "./actor-state.js";
 export type {
   EntityActor,
   AnyEntityActor,

--- a/test/actor-state.test.ts
+++ b/test/actor-state.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "effect-bun-test";
 import { Context, Effect, Fiber, Layer, Schema, Stream, SubscriptionRef } from "effect";
 import { ShardingConfig } from "effect/unstable/cluster";
-import { Actor } from "../src/index.js";
+import { Actor, ActorStateRegistry, listStateEntityIds } from "../src/index.js";
 
 const TestShardingConfig = ShardingConfig.layer({
   shardsPerGroup: 300,
@@ -164,6 +164,22 @@ describe("Actor state protocol", () => {
       expect(yield* state.get("state-service")).toBe(3);
       expect(yield* state.waitFor("state-service", (value) => value >= 3)).toBe(3);
       expect(yield* state.listEntityIds).toContain("state-service");
+    }));
+
+  test("the state registry is reachable from the barrel without an actor client", () =>
+    Effect.gen(function* () {
+      // A consumer that sits *beneath* an actor cannot yield that actor's
+      // `State` client to enumerate entities: the actor is built from the layer
+      // that would then depend on it. `ActorStateRegistry` is merged into the
+      // consumer's context by `toLayer`, so reading it directly is the
+      // cycle-free route — but only if the Tag is exported.
+      const makeRef = yield* Stateful.Context;
+      const ref = yield* makeRef("registry-direct");
+      yield* ref.execute(Stateful.Increment.make({ id: "registry-direct", amount: 1 }));
+
+      const registry = yield* ActorStateRegistry;
+      expect(yield* registry.list("Stateful")).toContain("registry-direct");
+      expect(yield* listStateEntityIds("Stateful")).toContain("registry-direct");
     }));
 
   test("Control service exposes bound mailbox operations", () =>


### PR DESCRIPTION
The registry was already reachable at runtime — `Actor.toLayer` merges `ActorStateRegistry.Live` into the consumer's context via `consumerSupportLayers`. The Tag just was not exported, so there was no way to name it.

That left the actor's own `State` client as the only route to enumerate live entities. It is unusable from anything built *beneath* the actor: requiring `ActorStateClientService<Name>` there makes the layer that builds the actor depend on the actor it builds.

## Exported

`ActorStateRegistry`, `ActorStateRegistryService`, `listStateEntityIds`, `stateOf`, `watchStateOf`, `waitForStateOf`.

`makeActorStateObservation` and `ActorStateObservation` stay internal — they are the decode machinery the `State` client is built from, not a consumer surface.

## Verification

New test reads the registry directly from the barrel. It fails to compile without the export (verified by removing it), so it measures the fix rather than restating it.

Gate green: type, lint, fmt, build, 298 tests.

https://claude.ai/code/session_01XfzMTL55ShZkcGB4wyUbcx